### PR TITLE
ci: build examples for multiple platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 jobs:
   todos_linux:
     runs-on: ubuntu-latest
@@ -10,7 +13,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v2
     - name: Install cargo-deb
       run: cargo install cargo-deb
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTED=noninteractive
@@ -37,7 +40,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: hecrj/setup-rust-action@v2
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Enable static CRT linkage
       run: |
         echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
@@ -57,7 +60,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: hecrj/setup-rust-action@v2
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Build todos binary
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.14
@@ -74,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: hecrj/setup-rust-action@v2
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install cross
       run: cargo install cross
     - name: Build todos binary for Raspberry Pi 3/4 (64 bits)

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,51 @@
+name: Example builds
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  native:
+    name: Build ${{ matrix.example }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        example: [counter, clock]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
+      - name: Build example
+        run: cargo build --release --example ${{ matrix.example }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.example }}-${{ matrix.os }}
+          path: target/release/examples/${{ matrix.example }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+
+  android:
+    name: Build ${{ matrix.example }} for Android
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: [counter, clock]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+      - name: Install Android target
+        run: rustup target add aarch64-linux-android
+      - name: Set up Android NDK
+        uses: nttld/setup-android@v2
+        with:
+          api-level: 33
+          ndk-version: 26.1.10909125
+      - name: Build example
+        run: cargo ndk -t aarch64-linux-android build --release --example ${{ matrix.example }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.example }}-aarch64-linux-android
+          path: target/aarch64-linux-android/release/examples/${{ matrix.example }}


### PR DESCRIPTION
## Summary
- run build workflow on pull requests
- build counter and clock examples for linux, macOS, windows and Android

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a42c4b52248320b98269a0308d30e4